### PR TITLE
FIX: Face Data Cleanup in ImageKit

### DIFF
--- a/src/main/kotlin/org/jagrati/jagratibackend/services/ImageKitService.kt
+++ b/src/main/kotlin/org/jagrati/jagratibackend/services/ImageKitService.kt
@@ -2,6 +2,8 @@ package org.jagrati.jagratibackend.services
 
 import org.apache.http.HttpHeaders
 import org.jagrati.jagratibackend.dto.imagekit.ImageKitResponse
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -18,6 +20,7 @@ class ImageKitService(
     private val privateKey: String
 ) {
     private val baseUrl = "https://api.imagekit.io/v1"
+    private val logger: Logger = LoggerFactory.getLogger(ImageKitService::class.java)
 
     private val client = WebClient.builder()
         .baseUrl(baseUrl)
@@ -34,6 +37,17 @@ class ImageKitService(
         )
     }
 
+    fun deleteFile(fileId: String){
+        val response = client.delete()
+            .uri("/files/$fileId")
+            .retrieve()
+            .toBodilessEntity()
+            .block()
+
+        if(response?.statusCode?.is2xxSuccessful != true){
+            logger.error("Failed to delete image ${response?.statusCode}")
+        }
+    }
 
     private fun generateSignature(token: String, expiry: Long): String {
         val message = token + expiry.toString()


### PR DESCRIPTION
This pull request introduces a mechanism to ensure that images stored in ImageKit are properly deleted whenever face data is updated or replaced, preventing orphaned files and ensuring data consistency. The main changes include integrating the `ImageKitService` for deletion operations, updating service methods to remove images before modifying face data, and adding robust error logging for failed deletions.

**Face Data Cleanup and ImageKit Integration:**

* Refactored `FaceDataService` to inject `ImageKitService` and added a new private method `removeImagesFromImageKit` which retrieves existing face data and deletes associated images (image, face, and frame) from ImageKit before updating or deleting records. [[1]](diffhunk://#diff-345856be5eeec1ace4a4300b53b7b7b34f8957362e5d4114887418626feff1b5L17-R28) [[2]](diffhunk://#diff-345856be5eeec1ace4a4300b53b7b7b34f8957362e5d4114887418626feff1b5R238-R255)
* Updated `addFaceData`, `updateFaceData`, and `addFaceDataForCurrentUser` methods in `FaceDataService` to call `removeImagesFromImageKit` and flush the repository before saving new face data, ensuring no orphaned images remain. [[1]](diffhunk://#diff-345856be5eeec1ace4a4300b53b7b7b34f8957362e5d4114887418626feff1b5L17-R28) [[2]](diffhunk://#diff-345856be5eeec1ace4a4300b53b7b7b34f8957362e5d4114887418626feff1b5L55-R60) [[3]](diffhunk://#diff-345856be5eeec1ace4a4300b53b7b7b34f8957362e5d4114887418626feff1b5R181)

**ImageKitService Enhancements:**

* Added a `deleteFile` method to `ImageKitService` that sends a DELETE request to ImageKit's API to remove files by `fileId`. It includes error logging if the deletion fails.
* Introduced a logger in `ImageKitService` for improved error tracking and debugging. [[1]](diffhunk://#diff-66e188bec351ccafee4af771b54e2e249a94f413348832259642933b0caefb12R5-R6) [[2]](diffhunk://#diff-66e188bec351ccafee4af771b54e2e249a94f413348832259642933b0caefb12R23)