### PR TITLE
Write .env before docker compose pull, not after

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -79,7 +79,6 @@ jobs:
           ssh prod-target bash -s <<'REMOTE_SCRIPT'
           set -e
           cd /opt/apps/production
-          docker compose pull
           cat > .env <<'ENV_FILE'
           BASE_URL=${{ secrets.PROD_BASE_URL }}
           POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}
@@ -94,6 +93,7 @@ jobs:
           MAIL_ID=${{ secrets.PROD_MAIL_ID }}
           FIREBASE_CREDENTIALS_BASE64=${{ secrets.PROD_FIREBASE_CREDENTIALS_BASE64 }}
           ENV_FILE
+          docker compose pull
           docker compose up -d
           docker compose ps
           REMOTE_SCRIPT

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -79,7 +79,6 @@ jobs:
           ssh staging-target bash -s <<'REMOTE_SCRIPT'
           set -e
           cd /opt/apps/staging
-          docker compose pull
           cat > .env <<'ENV_FILE'
           BASE_URL=${{ secrets.STAGING_BASE_URL }}
           POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}
@@ -94,6 +93,7 @@ jobs:
           MAIL_ID=${{ secrets.STAGING_MAIL_ID }}
           FIREBASE_CREDENTIALS_BASE64=${{ secrets.STAGING_FIREBASE_CREDENTIALS_BASE64 }}
           ENV_FILE
+          docker compose pull
           docker compose up -d
           docker compose ps
           REMOTE_SCRIPT


### PR DESCRIPTION
docker-compose.yaml references env_file: .env, so pull was failing outright when .env didn't exist yet. The previous ssh-action script had this same ordering bug but silently swallowed the failure since it never used set -e; the new raw-ssh script correctly aborts on it, which surfaced the bug.