### PR TITLE
Deploy: route SSH through SAC gateway proxy

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,7 +45,12 @@ jobs:
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
-          password: ${{secrets.PROD_PASSWORD}}
+          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
+          proxy_host: ${{ secrets.BASTION_HOST}}
+          proxy_username: ${{ secrets.BASTION_USERNAME }}
+          proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
           source: "docker/prod/docker-compose.yaml"
           target: "/opt/apps/production/"
           strip_components: 2

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -56,6 +56,11 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
+          proxy_host: ${{ secrets.BASTION_HOST}}
+          proxy_username: ${{ secrets.BASTION_USERNAME }}
+          proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+
           script: |
             cd /opt/apps/production
             /usr/bin/docker compose pull

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -40,45 +40,65 @@ jobs:
           docker push $IMAGE_TAG
           
 
+      - name: Setup SSH (jump through SAC proxy)
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}" > ~/.ssh/proxy_key
+          echo "${{ secrets.PROD_SSH_PRIVATE_KEY }}" > ~/.ssh/target_key
+          chmod 600 ~/.ssh/proxy_key ~/.ssh/target_key
+          cat >> ~/.ssh/config <<EOF
+          Host sac-proxy
+            HostName ${{ secrets.SAC_PROXY_HOST }}
+            User ${{ secrets.SAC_PROXY_USERNAME }}
+            IdentityFile ~/.ssh/proxy_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ConnectTimeout 10
+
+          Host prod-target
+            HostName ${{ secrets.PROD_HOST }}
+            User ${{ secrets.PROD_USERNAME }}
+            IdentityFile ~/.ssh/target_key
+            ProxyJump sac-proxy
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ConnectTimeout 10
+            ServerAliveInterval 5
+            ServerAliveCountMax 3
+          EOF
+          chmod 600 ~/.ssh/config
+
       - name: Copy docker-compose file to server
-        uses: appleboy/scp-action@v1.0.0
-        with:
-          host: ${{ secrets.PROD_HOST }}
-          username: ${{ secrets.PROD_USERNAME }}
-          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
-          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
-          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
-          source: "docker/prod/docker-compose.yaml"
-          target: "/opt/apps/production/"
-          strip_components: 2
+        run: |
+          ssh prod-target 'mkdir -p /opt/apps/production'
+          scp docker/prod/docker-compose.yaml prod-target:/opt/apps/production/docker-compose.yaml
 
       - name: Deploy production stack via SSH
-        uses: appleboy/ssh-action@v1.1.0
-        with:
-          host: ${{ secrets.PROD_HOST }}
-          username: ${{ secrets.PROD_USERNAME }}
-          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
-          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
-          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
-          script: |
-            cd /opt/apps/production
-            /usr/bin/docker compose pull
-            echo "BASE_URL=${{ secrets.PROD_BASE_URL }}" > .env
-            echo "POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}" >> .env
-            echo "POSTGRES_USER=${{ secrets.PROD_POSTGRES_USERNAME }}" >> .env
-            echo "POSTGRES_PASSWORD=${{ secrets.PROD_POSTGRES_PASSWORD }}" >> .env
-            echo "JWT_SECRET_BASE_64=${{ secrets.PROD_JWT_SECRET_BASE_64 }}" >> .env
-            echo "IMAGE_KIT_PRIVATE_KEY=${{ secrets.PROD_IMAGE_KIT_PRIVATE_KEY }}" >> .env
-            echo "OAUTH2_CLIENT_ID=${{ secrets.PROD_OAUTH2_CLIENT_ID }}" >> .env
-            echo "GMAIL_PASS=${{ secrets.PROD_GMAIL_PASS }}" >> .env
-            echo "ADMIN_MAIL=${{ secrets.PROD_ADMIN_MAIL }}" >> .env
-            echo "ADMIN_PASS=${{ secrets.PROD_ADMIN_PASS }}" >> .env
-            echo "MAIL_ID=${{ secrets.PROD_MAIL_ID }}" >> .env
-            echo "FIREBASE_CREDENTIALS_BASE64=${{ secrets.PROD_FIREBASE_CREDENTIALS_BASE64 }}" >> .env
-            /usr/bin/docker compose up -d
-            docker compose up -d
-            /usr/bin/docker compose ps
-            docker compose ps
+        run: |
+          ssh prod-target bash -s <<'REMOTE_SCRIPT'
+          set -e
+          cd /opt/apps/production
+          docker compose pull
+          cat > .env <<'ENV_FILE'
+          BASE_URL=${{ secrets.PROD_BASE_URL }}
+          POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}
+          POSTGRES_USER=${{ secrets.PROD_POSTGRES_USERNAME }}
+          POSTGRES_PASSWORD=${{ secrets.PROD_POSTGRES_PASSWORD }}
+          JWT_SECRET_BASE_64=${{ secrets.PROD_JWT_SECRET_BASE_64 }}
+          IMAGE_KIT_PRIVATE_KEY=${{ secrets.PROD_IMAGE_KIT_PRIVATE_KEY }}
+          OAUTH2_CLIENT_ID=${{ secrets.PROD_OAUTH2_CLIENT_ID }}
+          GMAIL_PASS=${{ secrets.PROD_GMAIL_PASS }}
+          ADMIN_MAIL=${{ secrets.PROD_ADMIN_MAIL }}
+          ADMIN_PASS=${{ secrets.PROD_ADMIN_PASS }}
+          MAIL_ID=${{ secrets.PROD_MAIL_ID }}
+          FIREBASE_CREDENTIALS_BASE64=${{ secrets.PROD_FIREBASE_CREDENTIALS_BASE64 }}
+          ENV_FILE
+          docker compose up -d
+          docker compose ps
+          REMOTE_SCRIPT
+
+      - name: Clean up SSH keys
+        if: always()
+        run: rm -f ~/.ssh/proxy_key ~/.ssh/target_key
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,7 +52,7 @@ jobs:
           proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
 
           source: "docker/prod/docker-compose.yaml"
-          target: "/opt/apps/production/"
+          target: "/home/jagriti/apps/production/"
           strip_components: 2
 
       - name: Deploy production stack via SSH
@@ -67,7 +67,7 @@ jobs:
           proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
 
           script: |
-            cd /opt/apps/production
+            cd /home/jagriti/apps/production
             /usr/bin/docker compose pull
             echo "BASE_URL=${{ secrets.PROD_BASE_URL }}" > .env
             echo "POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}" >> .env

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,12 +45,7 @@ jobs:
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
-          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-
-          proxy_host: ${{ secrets.BASTION_HOST}}
-          proxy_username: ${{ secrets.BASTION_USERNAME }}
-          proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-
+          password: ${{secrets.PROD_PASSWORD}}
           source: "docker/prod/docker-compose.yaml"
           target: "/opt/apps/production/"
           strip_components: 2

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -46,6 +46,9 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
+          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
           source: "docker/prod/docker-compose.yaml"
           target: "/opt/apps/production/"
           strip_components: 2
@@ -56,6 +59,9 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
+          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
           script: |
             cd /opt/apps/production
             /usr/bin/docker compose pull

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
-          password: ${{secrets.PROD_PASSWORD}}
+          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
           source: "docker/prod/docker-compose.yaml"
           target: "/opt/apps/production/"
           strip_components: 2
@@ -56,11 +56,6 @@ jobs:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
           key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-
-          proxy_host: ${{ secrets.BASTION_HOST}}
-          proxy_username: ${{ secrets.BASTION_USERNAME }}
-          proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
-
           script: |
             cd /opt/apps/production
             /usr/bin/docker compose pull

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -79,7 +79,6 @@ jobs:
           ssh prod-target bash -s <<'REMOTE_SCRIPT'
           set -e
           cd /opt/apps/production
-          docker compose pull
           cat > .env <<'ENV_FILE'
           BASE_URL=${{ secrets.PROD_BASE_URL }}
           POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}
@@ -94,6 +93,7 @@ jobs:
           MAIL_ID=${{ secrets.PROD_MAIL_ID }}
           FIREBASE_CREDENTIALS_BASE64=${{ secrets.PROD_FIREBASE_CREDENTIALS_BASE64 }}
           ENV_FILE
+          docker compose pull
           docker compose up -d
           docker compose ps
           REMOTE_SCRIPT

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,7 +52,7 @@ jobs:
           proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
 
           source: "docker/prod/docker-compose.yaml"
-          target: "/home/jagriti/apps/production/"
+          target: "/opt/apps/production/"
           strip_components: 2
 
       - name: Deploy production stack via SSH
@@ -67,7 +67,7 @@ jobs:
           proxy_key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
 
           script: |
-            cd /home/jagriti/apps/production
+            cd /opt/apps/production
             /usr/bin/docker compose pull
             echo "BASE_URL=${{ secrets.PROD_BASE_URL }}" > .env
             echo "POSTGRES_DB=${{ secrets.PROD_POSTGRES_DB }}" >> .env

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           host: ${{ secrets.PROD_HOST }}
           username: ${{ secrets.PROD_USERNAME }}
-          key: ${{ secrets.PROD_SSH_PRIVATE_KEY }}
+          password: ${{secrets.PROD_PASSWORD}}
           source: "docker/prod/docker-compose.yaml"
           target: "/opt/apps/production/"
           strip_components: 2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -56,11 +56,6 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-
-          proxy_host: ${{ secrets.BASTION_HOST}}
-          proxy_username: ${{ secrets.BASTION_USERNAME }}
-          proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-
           script: |
             cd /opt/apps/staging
             /usr/bin/docker compose pull

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
-          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          password: ${{ secrets.STAGING_PASSWORD }}
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,7 +52,7 @@ jobs:
           proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
 
           source: "docker/staging/docker-compose.yaml"
-          target: "/home/jagriti/apps/staging/"
+          target: "/opt/apps/staging/"
           strip_components: 2
 
       - name: Deploy staging stack via SSH
@@ -67,7 +67,7 @@ jobs:
           proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
 
           script: |
-            cd /home/jagriti/apps/staging
+            cd /opt/apps/staging
             /usr/bin/docker compose pull
             echo "BASE_URL=${{ secrets.STAGING_BASE_URL }}" > .env
             echo "POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}" >> .env

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -40,44 +40,64 @@ jobs:
           docker push $IMAGE_TAG
           
 
+      - name: Setup SSH (jump through SAC proxy)
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}" > ~/.ssh/proxy_key
+          echo "${{ secrets.STAGING_SSH_PRIVATE_KEY }}" > ~/.ssh/target_key
+          chmod 600 ~/.ssh/proxy_key ~/.ssh/target_key
+          cat >> ~/.ssh/config <<EOF
+          Host sac-proxy
+            HostName ${{ secrets.SAC_PROXY_HOST }}
+            User ${{ secrets.SAC_PROXY_USERNAME }}
+            IdentityFile ~/.ssh/proxy_key
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ConnectTimeout 10
+
+          Host staging-target
+            HostName ${{ secrets.STAGING_HOST }}
+            User ${{ secrets.STAGING_USERNAME }}
+            IdentityFile ~/.ssh/target_key
+            ProxyJump sac-proxy
+            StrictHostKeyChecking no
+            UserKnownHostsFile /dev/null
+            ConnectTimeout 10
+            ServerAliveInterval 5
+            ServerAliveCountMax 3
+          EOF
+          chmod 600 ~/.ssh/config
+
       - name: Copy docker-compose file to server
-        uses: appleboy/scp-action@v1.0.0
-        with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: ${{ secrets.STAGING_USERNAME }}
-          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
-          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
-          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
-          source: "docker/staging/docker-compose.yaml"
-          target: "/opt/apps/staging/"
-          strip_components: 2
+        run: |
+          ssh staging-target 'mkdir -p /opt/apps/staging'
+          scp docker/staging/docker-compose.yaml staging-target:/opt/apps/staging/docker-compose.yaml
 
       - name: Deploy staging stack via SSH
-        uses: appleboy/ssh-action@v1.1.0
-        with:
-          host: ${{ secrets.STAGING_HOST }}
-          username: ${{ secrets.STAGING_USERNAME }}
-          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
-          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
-          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
-          script: |
-            cd /opt/apps/staging
-            /usr/bin/docker compose pull
-            echo "BASE_URL=${{ secrets.STAGING_BASE_URL }}" > .env
-            echo "POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}" >> .env
-            echo "POSTGRES_USER=${{ secrets.STAGING_POSTGRES_USERNAME }}" >> .env
-            echo "POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD }}" >> .env
-            echo "JWT_SECRET_BASE_64=${{ secrets.STAGING_JWT_SECRET_BASE_64 }}" >> .env
-            echo "IMAGE_KIT_PRIVATE_KEY=${{ secrets.STAGING_IMAGE_KIT_PRIVATE_KEY }}" >> .env
-            echo "OAUTH2_CLIENT_ID=${{ secrets.STAGING_OAUTH2_CLIENT_ID }}" >> .env
-            echo "GMAIL_PASS=${{ secrets.STAGING_GMAIL_PASS }}" >> .env
-            echo "ADMIN_MAIL=${{ secrets.STAGING_ADMIN_MAIL }}" >> .env
-            echo "ADMIN_PASS=${{ secrets.STAGING_ADMIN_PASS }}" >> .env
-            echo "MAIL_ID=${{ secrets.STAGING_MAIL_ID }}" >> .env
-            echo "FIREBASE_CREDENTIALS_BASE64=${{ secrets.STAGING_FIREBASE_CREDENTIALS_BASE64 }}" >> .env
-            /usr/bin/docker compose up -d
-            docker compose up -d
-            /usr/bin/docker compose ps
-            docker compose ps
+        run: |
+          ssh staging-target bash -s <<'REMOTE_SCRIPT'
+          set -e
+          cd /opt/apps/staging
+          docker compose pull
+          cat > .env <<'ENV_FILE'
+          BASE_URL=${{ secrets.STAGING_BASE_URL }}
+          POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}
+          POSTGRES_USER=${{ secrets.STAGING_POSTGRES_USERNAME }}
+          POSTGRES_PASSWORD=${{ secrets.STAGING_POSTGRES_PASSWORD }}
+          JWT_SECRET_BASE_64=${{ secrets.STAGING_JWT_SECRET_BASE_64 }}
+          IMAGE_KIT_PRIVATE_KEY=${{ secrets.STAGING_IMAGE_KIT_PRIVATE_KEY }}
+          OAUTH2_CLIENT_ID=${{ secrets.STAGING_OAUTH2_CLIENT_ID }}
+          GMAIL_PASS=${{ secrets.STAGING_GMAIL_PASS }}
+          ADMIN_MAIL=${{ secrets.STAGING_ADMIN_MAIL }}
+          ADMIN_PASS=${{ secrets.STAGING_ADMIN_PASS }}
+          MAIL_ID=${{ secrets.STAGING_MAIL_ID }}
+          FIREBASE_CREDENTIALS_BASE64=${{ secrets.STAGING_FIREBASE_CREDENTIALS_BASE64 }}
+          ENV_FILE
+          docker compose up -d
+          docker compose ps
+          REMOTE_SCRIPT
+
+      - name: Clean up SSH keys
+        if: always()
+        run: rm -f ~/.ssh/proxy_key ~/.ssh/target_key

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,6 +46,11 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+
+          proxy_host: ${{ secrets.BASTION_HOST}}
+          proxy_username: ${{ secrets.BASTION_USERNAME }}
+          proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -79,7 +79,6 @@ jobs:
           ssh staging-target bash -s <<'REMOTE_SCRIPT'
           set -e
           cd /opt/apps/staging
-          docker compose pull
           cat > .env <<'ENV_FILE'
           BASE_URL=${{ secrets.STAGING_BASE_URL }}
           POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}
@@ -94,6 +93,7 @@ jobs:
           MAIL_ID=${{ secrets.STAGING_MAIL_ID }}
           FIREBASE_CREDENTIALS_BASE64=${{ secrets.STAGING_FIREBASE_CREDENTIALS_BASE64 }}
           ENV_FILE
+          docker compose pull
           docker compose up -d
           docker compose ps
           REMOTE_SCRIPT

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,7 +52,7 @@ jobs:
           proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
 
           source: "docker/staging/docker-compose.yaml"
-          target: "/opt/apps/staging/"
+          target: "/home/jagriti/apps/staging/"
           strip_components: 2
 
       - name: Deploy staging stack via SSH
@@ -67,7 +67,7 @@ jobs:
           proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
 
           script: |
-            cd /opt/apps/staging
+            cd /home/jagriti/apps/staging
             /usr/bin/docker compose pull
             echo "BASE_URL=${{ secrets.STAGING_BASE_URL }}" > .env
             echo "POSTGRES_DB=${{ secrets.STAGING_POSTGRES_DB }}" >> .env

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,6 +46,9 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
+          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2
@@ -56,6 +59,9 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          proxy_host: ${{ secrets.SAC_PROXY_HOST }}
+          proxy_username: ${{ secrets.SAC_PROXY_USERNAME }}
+          proxy_key: ${{ secrets.SAC_PROXY_SSH_PRIVATE_KEY }}
           script: |
             cd /opt/apps/staging
             /usr/bin/docker compose pull

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,11 +46,6 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-
-          proxy_host: ${{ secrets.BASTION_HOST}}
-          proxy_username: ${{ secrets.BASTION_USERNAME }}
-          proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
-
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
-          password: ${{ secrets.STAGING_PASSWORD }}
+          key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
           source: "docker/staging/docker-compose.yaml"
           target: "/opt/apps/staging/"
           strip_components: 2
@@ -56,6 +56,11 @@ jobs:
           host: ${{ secrets.STAGING_HOST }}
           username: ${{ secrets.STAGING_USERNAME }}
           key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+
+          proxy_host: ${{ secrets.BASTION_HOST}}
+          proxy_username: ${{ secrets.BASTION_USERNAME }}
+          proxy_key: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+
           script: |
             cd /opt/apps/staging
             /usr/bin/docker compose pull


### PR DESCRIPTION
## Summary
- Promotes the staging deploy workflow changes (already merged and tested on `dev`) to `master`, so production deploys use the same fix.
- The new backend server sits behind SAC's gateway on the internal `172.27.0.0/16` network with no public IP, unlike the old Webdock host these workflows were originally written for. Deploy steps now jump through SAC via a raw OpenSSH `ProxyJump` config instead of `appleboy/scp-action`/`appleboy/ssh-action`, which was hanging indefinitely after completing its work (a known issue with that library over double-hop connections).
- Also fixes an `.env`/`docker compose pull` ordering bug (pull was running before `.env` existed, which `docker-compose.yaml`'s `env_file: .env` reference needs) — this bug existed before too but was silently swallowed since the old script never used `set -e`.

## New secrets required (see PR #27 for full detail)
- `SAC_PROXY_HOST`, `SAC_PROXY_USERNAME`, `SAC_PROXY_SSH_PRIVATE_KEY`

## Secrets whose values need updating (names unchanged)
- `PROD_HOST` — now the backend server's **private** IP, not a public one
- `PROD_USERNAME`, `PROD_SSH_PRIVATE_KEY` — for the new backend server

## Test plan
- [x] Verified on staging via `dev` (PR #27, #28, #29) — SSH proxy jump and deploy complete cleanly
- [ ] Confirm `PROD_*` secrets are updated for the new server before merging
- [ ] Trigger `deploy-production` after merge and confirm it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)